### PR TITLE
Allow self-shaming and CoX support (both toggle-able on/off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Raid Shamer
-Takes a screenshot of deaths during Theater of Blood. Also supports discord webhook integration.
+Takes a screenshot of deaths during Theater of Blood/Chambers of Xeric. Supports discord webhook integration.
 
 Thanks to Zayre for the idea and socalova6 for bringing it to my attention.
 

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,5 +2,5 @@ displayName=Raid Shamer
 author=Botanophobia
 support=https://github.com/ejedev/raidshamer
 description=Takes a screenshot of deaths during Theater of Blood. Also supports discord webhook integration.
-tags=death, raid, raids, shame, tob, theater, discord, discord, webhook
+tags=death, raid, raids, shame, tob, theater, discord, webhook
 plugins=ejedev.raidshamer.RaidShamerPlugin

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Raid Shamer
 author=Botanophobia
 support=https://github.com/ejedev/raidshamer
-description=Takes a screenshot of deaths during Theater of Blood. Also supports discord webhook integration.
-tags=death, raid, raids, shame, tob, theater, discord, webhook
+description=Takes a screenshot of deaths during Theater of Blood/Chambers of Xeric. Supports discord webhook integration.
+tags=death, raid, raids, shame, tob, theater, cox, chambers, discord, webhook
 plugins=ejedev.raidshamer.RaidShamerPlugin

--- a/src/main/java/ejedev/raidshamer/RaidShamerConfig.java
+++ b/src/main/java/ejedev/raidshamer/RaidShamerConfig.java
@@ -8,11 +8,23 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("raidshamer")
 public interface RaidShamerConfig extends Config
 {
+
+    @ConfigItem(
+        keyName = "captureOwnDeaths",
+        name = "Own Deaths Captured",
+        description = "Allows you to toggle on/off own death shaming",
+        position = 1
+    )
+    default boolean captureOwnDeaths()
+    {
+        return true;
+    }
+
     @ConfigItem(
             keyName = "webhookEnabled",
             name = "Discord Webhook",
             description = "Allows you to send death photos automatically to a discord webhook. Read the github page for info.",
-            position = 1
+            position = 2
     )
     default boolean webhookEnabled()
     {
@@ -20,10 +32,10 @@ public interface RaidShamerConfig extends Config
     }
 
     @ConfigItem(
-            position = 2,
             keyName = "webhookLink",
             name = "Webhook URL",
-            description = "Put your webhook link here, the full thing copied from discord."
+            description = "Put your webhook link here, the full thing copied from discord.",
+            position = 3
     )
     default String webhookLink()
     {

--- a/src/main/java/ejedev/raidshamer/RaidShamerConfig.java
+++ b/src/main/java/ejedev/raidshamer/RaidShamerConfig.java
@@ -21,10 +21,21 @@ public interface RaidShamerConfig extends Config
     }
 
     @ConfigItem(
+        keyName = "activeInCoX",
+        name = "Active in Chambers of Xeric (CoX)",
+        description = "Allows for shaming in CoX",
+        position = 2
+    )
+    default boolean activeInCoX()
+    {
+        return true;
+    }
+
+    @ConfigItem(
             keyName = "webhookEnabled",
             name = "Discord Webhook",
             description = "Allows you to send death photos automatically to a discord webhook. Read the github page for info.",
-            position = 2
+            position = 3
     )
     default boolean webhookEnabled()
     {
@@ -35,7 +46,7 @@ public interface RaidShamerConfig extends Config
             keyName = "webhookLink",
             name = "Webhook URL",
             description = "Put your webhook link here, the full thing copied from discord.",
-            position = 3
+            position = 4
     )
     default String webhookLink()
     {

--- a/src/main/java/ejedev/raidshamer/RaidShamerPlugin.java
+++ b/src/main/java/ejedev/raidshamer/RaidShamerPlugin.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 
 @PluginDescriptor(
         name = "Raid Shamer",
-        description = "Takes a screenshot of deaths during Theater of Blood. Also supports discord webhook integration.",
+        description = "Takes a screenshot of deaths during Theater of Blood. Supports discord webhook integration.",
         tags = {"death", "raid", "raids", "shame", "tob", "theater", "discord", "webhook"},
         loadWhenOutdated = true,
         enabledByDefault = false
@@ -60,7 +60,7 @@ public class RaidShamerPlugin extends Plugin{
         if (actor instanceof Player)
         {
             Player player = (Player) actor;
-            if (inTob)
+            if (shouldTakeScreenshot(player))
             {
                 takeScreenshot("Death of " + player.getName(), "Wall of Shame");
             }
@@ -68,6 +68,12 @@ public class RaidShamerPlugin extends Plugin{
                 System.out.println("[DEBUG] Not in tob sorry.");
             }
         }
+    }
+
+    private boolean shouldTakeScreenshot(Player player) {
+        boolean isPlayerValidTarget = config.captureOwnDeaths() ||
+            (!config.captureOwnDeaths() && player != client.getLocalPlayer());
+        return inTob && isPlayerValidTarget;
     }
 
     @Subscribe

--- a/src/main/java/ejedev/raidshamer/RaidShamerPlugin.java
+++ b/src/main/java/ejedev/raidshamer/RaidShamerPlugin.java
@@ -22,12 +22,12 @@ import java.util.function.Consumer;
 
 @PluginDescriptor(
         name = "Raid Shamer",
-        description = "Takes a screenshot of deaths during Theater of Blood. Supports discord webhook integration.",
-        tags = {"death", "raid", "raids", "shame", "tob", "theater", "discord", "webhook"},
+        description = "Takes a screenshot of deaths during Theater of Blood/Chambers of Xeric. Supports discord webhook integration.",
+        tags = {"death", "raid", "raids", "shame", "tob", "theater", "cox", "chambers", "discord", "webhook"},
         loadWhenOutdated = true,
         enabledByDefault = false
 )
-public class RaidShamerPlugin extends Plugin{
+public class RaidShamerPlugin extends Plugin {
 
     @Inject
     private Client client;
@@ -73,7 +73,10 @@ public class RaidShamerPlugin extends Plugin{
     private boolean shouldTakeScreenshot(Player player) {
         boolean isPlayerValidTarget = config.captureOwnDeaths() ||
             (!config.captureOwnDeaths() && player != client.getLocalPlayer());
-        return inTob && isPlayerValidTarget;
+        boolean inRaid = client.getVar(Varbits.IN_RAID) > 0;
+        boolean isInValidRaid = inTob || (config.activeInCoX() && inRaid);
+        
+        return isInValidRaid && isPlayerValidTarget;
     }
 
     @Subscribe

--- a/src/main/java/ejedev/raidshamer/RaidShamerPlugin.java
+++ b/src/main/java/ejedev/raidshamer/RaidShamerPlugin.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 @PluginDescriptor(
         name = "Raid Shamer",
         description = "Takes a screenshot of deaths during Theater of Blood. Also supports discord webhook integration.",
-        tags = {"death", "raid", "raids", "shame", "tob", "theater", "discord", "discord", "webhook"},
+        tags = {"death", "raid", "raids", "shame", "tob", "theater", "discord", "webhook"},
         loadWhenOutdated = true,
         enabledByDefault = false
 )
@@ -60,7 +60,7 @@ public class RaidShamerPlugin extends Plugin{
         if (actor instanceof Player)
         {
             Player player = (Player) actor;
-            if (player != client.getLocalPlayer() && inTob)
+            if (inTob)
             {
                 takeScreenshot("Death of " + player.getName(), "Wall of Shame");
             }


### PR DESCRIPTION
Allows for self-shaming:
- Otherwise multiple members need the plugin - and you end up with duplicate shamings if you want all deaths to be shamed.

- Added a config flag to toggle self shaming on/off.

Allow for Cox shaming:

- Added a config flag to toggle Cox support on/off.

Also, removed duplicate tag "discord"